### PR TITLE
feat: added logarithmic quantizer

### DIFF
--- a/examples/non_uniform_demo.py
+++ b/examples/non_uniform_demo.py
@@ -1,0 +1,51 @@
+import warnings
+import torch
+
+warnings.filterwarnings(
+    "ignore", category=UserWarning, module="torch._subclasses.functional_tensor"
+)
+
+from inwhale.core.non_uniform import LogarithmicQuantizer
+from inwhale.observers.minmax import MinMaxObserver
+from inwhale.rounding.nearest import NearestRounding
+
+
+# Input tensor
+x = torch.tensor([1.013, 2.513, -3.264, 0.235, -0.251, 0.012])
+
+observer = MinMaxObserver()
+rounding = NearestRounding()
+
+quant = LogarithmicQuantizer(
+    bits=8,
+    observer=observer,
+    rounding=rounding,
+)
+
+"""
+Logarithmic quantization intuition:
+
+We represent values as:
+    sign(x) * 2^k
+
+Steps:
+1. Observer records min/max of x
+2. Compute max_abs = max(|min|, |max|)
+3. Convert max_abs to log2 domain
+4. Round exponent and clamp to representable exponent range
+5. For each non-zero x:
+   - k = round(log2(|x|))
+   - qx = sign(x) * 2^k
+
+Zero stays zero.
+
+This favors scale invariance over linear precision.
+"""
+
+qx = quant.quantize(x)
+dx = quant.dequantize(qx)
+
+print("Original:", x)
+print("Quantized:", qx)
+print("Dequantized:", dx)
+print("Absolute error:", (x - dx).abs())

--- a/inwhale/core/non_uniform.py
+++ b/inwhale/core/non_uniform.py
@@ -1,0 +1,45 @@
+import torch
+
+from .quantizer import BaseQuantizer
+
+
+class LogarithmicQuantizer(BaseQuantizer):
+    def __init__(self, bits, observer, rounding):
+        super().__init__(bits)
+        self.observer = observer
+        self.rounding = rounding
+
+        self.emin = -(1 << (bits - 1))
+        self.emax = (1 << (bits - 1)) - 1
+
+    def _compute_scale(self):
+        min_val, max_val = self.observer.get_range()
+
+        max_abs = torch.max(min_val.abs(), max_val.abs())
+        max_abs = torch.clamp(max_abs, min=1e-8)
+
+        max_exp = torch.log2(max_abs)
+        self.exp_max = torch.clamp(self.rounding.round(max_exp), self.emin, self.emax)
+
+        self.exp_min = self.emin
+
+    def quantize(self, x):
+        self.observer.observe(x)
+        self._compute_scale()
+
+        qx = torch.zeros_like(x)
+        non_zero = x != 0  # (x != 0).float()
+
+        sign_x = torch.sign(x[non_zero])
+        abs_x = x[non_zero].abs()
+
+        log_x = torch.log2(abs_x)
+        k = self.rounding.round(log_x)
+        k = torch.clamp(k, self.exp_min, self.exp_max)
+
+        qx[non_zero] = sign_x * torch.pow(2.0, k)
+
+        return qx
+
+    def dequantize(self, qx):
+        return qx

--- a/tests/test_logarithmic_nonuniform.py
+++ b/tests/test_logarithmic_nonuniform.py
@@ -1,0 +1,80 @@
+import torch
+
+from inwhale.core.non_uniform import LogarithmicQuantizer
+from inwhale.observers.minmax import MinMaxObserver
+from inwhale.rounding.nearest import NearestRounding
+
+
+def make_quant(bits=4):
+    obs = MinMaxObserver()
+    rnd = NearestRounding()
+    return LogarithmicQuantizer(bits=bits, observer=obs, rounding=rnd)
+
+
+def test_exponent_boundaries():
+    q = make_quant(bits=4)
+
+    assert q.emin == -(1 << (4 - 1))
+    assert q.emax == (1 << (4 - 1)) - 1
+
+
+def test_zero_is_preserved():
+    x = torch.zeros(10)
+    q = make_quant(bits=4)
+
+    qx = q.quantize(x)
+    dx = q.dequantize(qx)
+
+    assert torch.all(qx == 0)
+    assert torch.all(dx == 0)
+
+
+def test_quantized_values_are_powers_of_two():
+    x = torch.tensor([0.25, 0.5, 1.0, 2.0, 3.0, 6.0])
+    q = make_quant(bits=5)
+
+    qx = q.quantize(x)
+
+    non_zero = qx[qx != 0].abs()
+    log2_vals = torch.log2(non_zero)
+
+    # Quantized magnitudes must be integer powers of two
+    assert torch.allclose(log2_vals, torch.round(log2_vals))
+
+
+def test_sign_is_preserved():
+    x = torch.tensor([-0.5, -2.0, 1.5, 4.0])
+    q = make_quant(bits=4)
+
+    qx = q.quantize(x)
+
+    assert torch.all(torch.sign(qx) == torch.sign(x))
+
+
+def test_larger_magnitude_monotonicity():
+    x = torch.tensor([0.25, 0.5, 1.0, 2.0, 4.0])
+    q = make_quant(bits=4)
+
+    qx = q.quantize(x)
+
+    # Log quantization should preserve ordering by magnitude
+    assert torch.all(qx[:-1].abs() <= qx[1:].abs())
+
+
+def test_observer_is_used():
+    obs = MinMaxObserver()
+    rnd = NearestRounding()
+    q = LogarithmicQuantizer(bits=4, observer=obs, rounding=rnd)
+
+    x1 = torch.tensor([1.0, 2.0])
+    q.quantize(x1)
+
+    min1, max1 = obs.get_range()
+
+    x2 = torch.tensor([0.5, 8.0])
+    q.quantize(x2)
+
+    min2, max2 = obs.get_range()
+
+    assert min2 <= min1
+    assert max2 >= max1


### PR DESCRIPTION
fixes #9 

## Implemented Logarithmic Quantizer

### Changes

1. Added `core/non_uniform.py` entry for `LogarithmicQuantizer`.
2. Added `examples/non_uniform_demo.py`.
3. Added `tests/test_logarithmic_nonuniform.py`.

### Checklist

* [x] Code placed in the appropriate module
* [ ] Docstrings included
* [x] Tests added
* [x] Code formatted and readable
* [x] No unused debug statements or prints

### Note

> [!IMPORTANT]  
> Will add docstrings in a future commit.
> AI generated `example` and `test` scripts.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added LogarithmicQuantizer class for non-uniform quantization using logarithmic scaling
  * Added example script demonstrating LogarithmicQuantizer usage with configurable observer and rounding strategies

* **Tests**
  * Added comprehensive test suite validating exponent boundaries, zero preservation, magnitude properties, sign preservation, and observer behavior

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->