### PR TITLE
Add mid-tread and mid-rise uniform quantizers

### DIFF
--- a/examples/mid_tread_mid_rise.py
+++ b/examples/mid_tread_mid_rise.py
@@ -32,7 +32,7 @@ def main():
     print("x = ", qx_rise)
     print("x' =", dx_rise)
 
-    if __name__ == "__main__":
-        main()
+if __name__ == "__main__":
+    main()
 
         

--- a/examples/mid_tread_mid_rise.py
+++ b/examples/mid_tread_mid_rise.py
@@ -29,7 +29,8 @@ def main():
     dx_rise = mid_rise.dequantize(qx_rise)
 
     print("Mid-rise quantization:")
-    print("x = ", qx_rise)
+    print("x = ", x)
+    print("qx = ", qx_rise)
     print("x' =", dx_rise)
 
 if __name__ == "__main__":

--- a/examples/mid_tread_mid_rise.py
+++ b/examples/mid_tread_mid_rise.py
@@ -1,0 +1,38 @@
+import torch
+
+from inwhale.core.uniform import (
+    MidTreadUniformQuantizer,
+    MidRiseUniformQuantizer,
+)
+from inwhale.observers.minmax import MinMaxObserver
+from inwhale.rounding.nearest import NearestRounding
+
+def main():
+    x  = torch.tensor([-1.2, -0.3, 0.0, 0.4, 1.7])
+
+    observer = MinMaxObserver()
+    rounding = NearestRounding()
+
+    mid_tread = MidTreadUniformQuantizer(bits=8, observer=observer, rounding=rounding)
+    qx_tread = mid_tread.quantize(x)
+    dx_tread = mid_tread.dequantize(qx_tread)
+
+    print("Mid-tread quantization: ")
+    print("x =", x)
+    print("qx = ", qx_tread)
+    print("x' = ", dx_tread)
+    print()
+
+    observer = MinMaxObserver()
+    mid_rise = MidRiseUniformQuantizer(bits=8, observer=observer, rounding=rounding)
+    qx_rise = mid_rise.quantize(x)
+    dx_rise = mid_rise.dequantize(qx_rise)
+
+    print("Mid-rise quantization:")
+    print("x = ", qx_rise)
+    print("x' =", dx_rise)
+
+    if __name__ == "__main__":
+        main()
+
+        

--- a/inwhale/core/uniform.py
+++ b/inwhale/core/uniform.py
@@ -253,9 +253,9 @@ class MidTreadUniformQuantizer(BaseQuantizer):
     q = round(x / scale)
     x' = q * scale
     attributes:
-    n_bits : number of bits for quantization
-    x_min : minimum value of input range
-    x_max : maximum value of input range
+    bits : number of bits for quantization
+    min : minimum value of input range
+    max : maximum value of input range
     scale : quantization step size
     """
     def __init__(self, bits, observer, rounding): # initialize mid-tread quantizer
@@ -321,7 +321,8 @@ class MidRiseUniformQuantizer(BaseQuantizer):
         self.observer.observe(x)
         self._compute_scale()
 
-        qx = torch.floor(x / self.scale) + 0.5
+        qx = x / self.scale - 0.5
+        qx = self.rounding.round(qx)
         qx = torch.clamp(qx, self.qmin, self.qmax)
         return qx
     

--- a/tests/test_mid_tread_mid_rise.py
+++ b/tests/test_mid_tread_mid_rise.py
@@ -1,0 +1,31 @@
+import torch
+
+from inwhale.core.uniform import(
+    MidTreadUniformQuantizer,
+    MidRiseUniformQuantizer,
+)
+
+from inwhale.observers.minmax import MinMaxObserver
+from inwhale.rounding.nearest import NearestRounding
+
+def test_mid_tread_has_zero_level():
+    observer = MinMaxObserver()
+    rounding = NearestRounding()
+    quantizer = MidTreadUniformQuantizer(bits=8, observer=observer, rounding=rounding)
+
+    x = torch.tensor([-0.2, 0.0, 0.3])
+    qx = quantizer.quantize(x)
+
+    assert torch.any(qx == 0)
+
+def test_mid_rise_has_no_zero_level():
+    observer = MinMaxObserver()
+    rounding = NearestRounding()
+    quantizer = MidRiseUniformQuantizer(bits=8, observer=observer, rounding=rounding)
+
+    x = torch.tensor([-0.2, 0.0, 0.3])
+    qx = quantizer.quantize(x)
+
+    assert not torch.any(qx == 0)
+
+    


### PR DESCRIPTION
### Description
Implements mid-tread and mid-rise uniform quantizers as part of uniform quantization.

### Changes
- Added MidTreadUniformQuantizer
- Added MidRiseUniformQuantizer
- Added unit tests
- Added example usage

### Checklist
- [x] Implementation
- [x] Documentation
- [x] Tests
- [x] Examples

Closes #4


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added two uniform quantizers with distinct behaviors (one yields a zero quantization level; the other does not).

* **Examples**
  * Added an example script demonstrating usage of both quantizers and showing their quantize/dequantize outputs.

* **Tests**
  * Added tests verifying expected quantization behavior (presence or absence of a zero level) for each quantizer.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->