### PR TITLE
Add per-channel uniform quantization

### DIFF
--- a/examples/per_channel_quantization.py
+++ b/examples/per_channel_quantization.py
@@ -6,13 +6,13 @@ from inwhale.rounding.nearest import NearestRounding
 
 x = torch.tensor([
     [-1.0, 1.0, 0.5, -0.5],
-    [-10.0, 15.0, 8.0, -5,0],
+    [-10.0, 15.0, 8.0, -5.0],
 ])
 observer = MinMaxObserver(axis=0)
 rounding = NearestRounding()
 
 q = PerChannelAsymmetricUniformQuantizer(
-    bits=8, observer=observer, rounidng=rounding, axis=0, signed=True,
+    bits=8, observer=observer, rounding=rounding, axis=0, signed=True,
 )
 
 """

--- a/examples/per_channel_quantization.py
+++ b/examples/per_channel_quantization.py
@@ -1,0 +1,62 @@
+import torch
+
+from inwhale.core.uniform import PerChannelAsymmetricUniformQuantizer
+from inwhale.observers.minmax import MinMaxObserver
+from inwhale.rounding.nearest import NearestRounding
+
+x = torch.tensor([
+    [-1.0, 1.0, 0.5, -0.5],
+    [-10.0, 15.0, 8.0, -5,0],
+])
+observer = MinMaxObserver(axis=0)
+rounding = NearestRounding()
+
+q = PerChannelAsymmetricUniformQuantizer(
+    bits=8, observer=observer, rounidng=rounding, axis=0, signed=True,
+)
+
+"""
+what the oberver sees (perchannel)
+channel 0:
+min = -1.0, max = 1.0
+channel 1:
+min = -10.0, max = 15.0
+
+for 8-bit signed quantization:
+qmin = -128, qmax = 127
+
+scale computation:
+channel 0:
+scale[0] = min - max / qmax - qmin = 2 / 255 = 0.00784
+channel 1:
+scale[1] = 15 - (-10) / 255 = 0.09804
+
+zero_point[c] = round(qmin - min / scale)
+
+//quantization
+q = round(x / scale) + zero_point
+
+//dequantization
+x' = (q - zero_point) * scale
+
+"""
+qx = q.quantize(x)
+dx = q.dequantize(qx)
+
+print("Original:")
+print(x)
+
+print("Quantized (per-channel):")
+print(qx)
+
+print("Dequantized:")
+print(dx)
+
+print("Absolute error:")
+print((x - dx).abs())
+
+print("Per-channel scales:")
+print(q.scale)
+
+print("Per-channel zero-points:")
+print(q.zero_point)

--- a/inwhale/core/uniform.py
+++ b/inwhale/core/uniform.py
@@ -362,9 +362,10 @@ class PerChannelAsymmetricUniformQuantizer(BaseQuantizer):
     def __init__(self, bits, observer, rounding, axis=0, signed=False):
         super().__init__(bits)
 
+        self.bits = bits
         self.axis = axis
-        self.observer = observer
         self.rounding = rounding
+        self.signed = signed
 
         if signed:
             self.qmin = -(1 << (bits - 1))

--- a/inwhale/core/uniform.py
+++ b/inwhale/core/uniform.py
@@ -396,7 +396,6 @@ class PerChannelAsymmetricUniformQuantizer(BaseQuantizer):
             observer = MinMaxObserver()
             observer.observe(x_c)
             min_val, max_val = observer.get_range()
-            min_val, max_val = self.observer.get_range()
 
             if max_val == min_val:
                 scale = torch.tensor(1.0, device=x.device)

--- a/tests/test_per_channel.py
+++ b/tests/test_per_channel.py
@@ -1,0 +1,125 @@
+import torch
+
+from inwhale.core.uniform import (
+    AsymmetricUniformQuantizer,
+    PerChannelAsymmetricUniformQuantizer,
+)
+from inwhale.observers.minmax import MinMaxObserver
+from inwhale.rounding.nearest import NearestRounding
+from inwhale.observers.minmax import MinMaxObserver
+
+
+def test_per_channel_scale_and_zero_point_shapes():
+    """
+    Per-channel quantization should produce one scale and zero-point per channel.
+    """
+    x = torch.tensor([
+        [-1.0,  1.0],
+        [-10.0, 10.0],
+        [-0.5,  0.5],
+    ])
+
+    observer = MinMaxObserver()
+    rounding = NearestRounding()
+    q = PerChannelAsymmetricUniformQuantizer(
+        bits=8, observer=observer, rounding=rounding, axis=0, signed=True,
+    )
+    observer.observe(x)
+    q.quantize(x)
+
+    assert q.scale.ndim == 1
+    assert q.zero_point.ndim == 1
+    assert q.scale.numel() == x.shape[0]
+    assert q.zero_point.numel() == x.shape[0]
+
+
+def test_per_channel_differs_from_per_tensor():
+    """
+    Per-channel quantization should behave differently from per-tensor
+    when channels have very different ranges.
+    """
+    x = torch.tensor([
+        [-1.0,  1.0,  0.5, -0.5],     # small range
+        [-10.0, 15.0, 8.0, -5.0],     # large range
+    ])
+
+    obs = MinMaxObserver()
+    rnd = NearestRounding()
+
+    per_tensor = AsymmetricUniformQuantizer(
+        bits=8, observer=obs, rounding=rnd, signed=True
+    )
+    per_channel = PerChannelAsymmetricUniformQuantizer(
+        bits=8, observer=obs, rounding=rnd, axis=0, signed=True
+    )
+
+    per_tensor.quantize(x)
+    per_channel.quantize(x)
+
+    # channel 0 should differ due to independent scaling
+    assert per_tensor.scale.ndim == 0
+    assert per_channel.scale.ndim == 1
+    assert per_channel.scale.numel() == x.shape[0]
+
+
+
+def test_per_channel_zero_range_channel():
+    """
+    A channel with zero range (min == max) should be handled safely.
+    """
+    x = torch.tensor([
+        [3.14, 3.14, 3.14],   # zero-range channel
+        [-2.0, 0.0, 2.0],
+    ])
+
+    obs = MinMaxObserver()
+    rnd = NearestRounding()
+    q = PerChannelAsymmetricUniformQuantizer(
+        bits=8, observer=obs, rounding=rnd, axis=0, signed=True
+    )
+    obs.observe(x)
+    qx = q.quantize(x)
+    dx = q.dequantize(qx)
+
+    assert torch.isfinite(dx).all()
+
+
+def test_per_channel_round_trip_accuracy():
+    """
+    Dequantized values should be close to original values within one scale step,
+    per channel.
+    """
+    x = torch.tensor([
+        [-1.0, 0.0, 1.0],
+        [-10.0, 0.0, 10.0],
+    ])
+
+    obs = MinMaxObserver()
+    rnd = NearestRounding()
+    q = PerChannelAsymmetricUniformQuantizer(
+        bits=8, observer=obs, rounding=rnd, axis=0, signed=True
+    )
+    obs.observe(x)
+    qx = q.quantize(x)
+    dx = q.dequantize(qx)
+
+    for c in range(x.shape[0]):
+        assert torch.allclose(dx[c], x[c], atol=float(q.scale[c]))
+
+
+def test_per_channel_quantized_values_within_range():
+    """
+    Quantized values must lie within [qmin, qmax] for all channels.
+    """
+    x = torch.randn(4, 10)
+
+    obs = MinMaxObserver()
+    rnd = NearestRounding()
+    q = PerChannelAsymmetricUniformQuantizer(
+        bits=8, observer=obs, rounding=rnd, axis=0, signed=True
+    )
+    obs.observe(x)
+    qx = q.quantize(x)
+
+    assert torch.all(qx >= q.qmin)
+    assert torch.all(qx <= q.qmax)


### PR DESCRIPTION
Adds per-channel asymmetric uniform quantization.
Per-tensor asymmetric uniform quantization was already implemented; this PR extends it by adding per-channel support for improved accuracy when channel ranges differ.

### Checklist
- [x] Implementation
- [x] Tests
- [x] Example
- [x] Documentation



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Per-channel asymmetric uniform quantization: computes per-channel scales and zero-points for finer-grained quantization.

* **Documentation**
  * Added an example demonstrating per-channel quantize/dequantize flow with printed diagnostics (original, quantized, dequantized, error, per-channel scales/zero-points).

* **Tests**
  * New unit tests validating per-channel shapes, bounds, zero-range handling, and round-trip accuracy.

* **Bug Fixes**
  * Adjusted uniform quantization computation to improve quantized-value behavior.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->