### PR TITLE
feat: implement NF4 and FP4 quantizers for LLM-specific category

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -109,14 +109,14 @@ Use descriptive messages:
 git push origin feature-your-feature
 ```
 
-2. Open a Pull Request.
-3. In the PR description, include:
+1. Open a Pull Request.
+2. In the PR description, include:
 
    * What you implemented
    * Why it is useful
    * Any mathematical references
    * Tests added
-4. Wait for review and make requested updates.
+3. Wait for review and make requested updates.
 
 PRs should be small and focused. Avoid mixing multiple features.
 
@@ -153,4 +153,3 @@ Examples:
 * Write a tutorial demonstrating how symmetric vs asymmetric quantization differ.
 * Add plots showing quantization error.
 * Add explanations inside docstrings.
-

--- a/examples/llm_quantization_demo.py
+++ b/examples/llm_quantization_demo.py
@@ -1,0 +1,47 @@
+import torch
+import matplotlib.pyplot as plt
+from inwhale.llm.formats import NF4Quantizer, FP4Quantizer
+
+def demo_llm_quantization():
+    print("=== NF4 and FP4 Quantization Demo ===")
+    
+    # 1. Create normally distributed "weights"
+    torch.manual_seed(42)
+    weights = torch.randn(1000)
+    
+    print(f"\nOriginal Weights:")
+    print(f"Shape: {weights.shape}, Min: {weights.min():.4f}, Max: {weights.max():.4f}, Mean: {weights.mean():.4f}")
+    
+    # 2. Initialize the quantizers
+    nf4_quantizer = NF4Quantizer()
+    fp4_quantizer = FP4Quantizer()
+    
+    # 3. Quantize the weights
+    nf4_q, nf4_scale = nf4_quantizer.quantize(weights)
+    fp4_q, fp4_scale = fp4_quantizer.quantize(weights)
+    
+    # 4. Dequantize
+    nf4_deq = nf4_quantizer.dequantize(nf4_q, nf4_scale)
+    fp4_deq = fp4_quantizer.dequantize(fp4_q, fp4_scale)
+    
+    # 5. Compute Error
+    nf4_error = torch.nn.functional.mse_loss(weights, nf4_deq)
+    fp4_error = torch.nn.functional.mse_loss(weights, fp4_deq)
+    
+    print("\nQuantization Errors (MSE vs Original):")
+    print(f"NF4 Error: {nf4_error.item():.6f}")
+    print(f"FP4 Error: {fp4_error.item():.6f}")
+    
+    # Notice that NF4 has lower MSE error for normally distributed weights
+    # compared to FP4, which is the key finding from the QLoRA paper.
+    print(f"\nNF4 is {'better' if nf4_error < fp4_error else 'worse'} than FP4 for normal distribution by {(fp4_error - nf4_error).abs().item():.6f} MSE.")
+    
+    # Show values distribution
+    print("\nFirst 10 Weights comparison:")
+    print("Original |   NF4   |   FP4")
+    print("-" * 35)
+    for i in range(10):
+        print(f"{weights[i].item():>8.4f} | {nf4_deq[i].item():>7.4f} | {fp4_deq[i].item():>7.4f}")
+
+if __name__ == "__main__":
+    demo_llm_quantization()

--- a/inwhale/llm/__init__.py
+++ b/inwhale/llm/__init__.py
@@ -1,0 +1,3 @@
+from .formats import NF4Quantizer, FP4Quantizer
+
+__all__ = ["NF4Quantizer", "FP4Quantizer"]

--- a/inwhale/llm/formats.py
+++ b/inwhale/llm/formats.py
@@ -1,0 +1,119 @@
+import torch
+from inwhale.core.quantizer import BaseQuantizer
+
+class NF4Quantizer(BaseQuantizer):
+    """
+    NormalFloat4 (NF4) Quantizer.
+    
+    This implements the NF4 format as described in the QLoRA paper (Dettmers et al., 2023).
+    NF4 is an information-theoretically optimal data type for normally distributed weights.
+    The quantiles of a standard normal distribution are used to create a 4-bit representation
+    with 16 values, normalized to the range [-1, 1].
+    
+    Math:
+    Let Q be the set of 16 NF4 quantiles.
+    For an input tensor X, we first normalize it by its absolute maximum:
+        scale = max(abs(X))
+        X_norm = X / scale
+    Then each element in X_norm is mapped to the nearest value in Q:
+        X_quant = argmin_{q in Q} abs(X_norm - q)
+    Dequantization is simply:
+        X_dequant = X_quant * scale
+    """
+    
+    def __init__(self):
+        super().__init__(bits=4)
+        # NF4 values from QLoRA paper, normalized to [-1, 1]
+        nf4_values = [
+            -1.0, -0.6961928009986877, -0.5250730514526367, -0.39491748809814453,
+            -0.28444138169288635, -0.18477343022823334, -0.09105003625154495, 0.0,
+            0.07958029955625534, 0.16093020141124725, 0.24611230194568634, 0.33791524171829224,
+            0.44070982933044434, 0.5626170039176941, 0.7229568362236023, 1.0
+        ]
+        # Store as a sorted tensor for efficient search
+        self.register_buffer("quantiles", torch.tensor(nf4_values, dtype=torch.float32))
+        
+    def register_buffer(self, name, tensor):
+        # Using simple attribute assignment since BaseQuantizer is not an nn.Module
+        setattr(self, name, tensor)
+
+    def quantize(self, x: torch.Tensor):
+        """
+        Quantizes the input tensor using NF4.
+        Returns the quantized (but still float-typed) values mapped to the NF4 quantiles,
+        and the scale factor used.
+        """
+        self.scale = x.abs().max()
+        if self.scale == 0:
+            return torch.zeros_like(x), self.scale
+            
+        x_norm = x / self.scale
+        
+        # Broadcasting to find the nearest quantile
+        # x_norm: [..., 1], quantiles: [16]
+        diffs = torch.abs(x_norm.unsqueeze(-1) - self.quantiles.to(x.device))
+        indices = torch.argmin(diffs, dim=-1)
+        
+        # Map indices back to quantile values
+        qx = self.quantiles.to(x.device)[indices]
+        return qx, self.scale
+
+    def dequantize(self, qx: torch.Tensor, scale: torch.Tensor):
+        """
+        Dequantizes the NF4 representation back to original scale.
+        """
+        return qx * scale
+
+
+class FP4Quantizer(BaseQuantizer):
+    """
+    Float4 (FP4) Quantizer (E2M1).
+    
+    This implements a 4-bit floating point format with 1 sign bit, 2 exponent bits, 
+    and 1 mantissa bit (E2M1), often used in LLM quantization.
+    
+    Math:
+    The standard E2M1 representation provides 16 values. When normalized to [-1, 1],
+    these values represent points linearly or logarithmically spaced depending on the 
+    exponent. The positive values (before normalization) are typically:
+    0, 0.5, 1.0, 1.5, 2.0, 3.0, 4.0, 6.0
+    Normalized to [-1, 1] by dividing by 6.0, we get the FP4 quantiles.
+    
+    Quantization finds the nearest FP4 value for absolute-max normalized input.
+    """
+    
+    def __init__(self):
+        super().__init__(bits=4)
+        # E2M1 positive values: 0, 0.5, 1, 1.5, 2, 3, 4, 6
+        # Normalized by max value 6:
+        pos_values = [0.0, 0.5/6, 1.0/6, 1.5/6, 2.0/6, 3.0/6, 4.0/6, 1.0]
+        neg_values = [-v for v in reversed(pos_values[1:])]
+        fp4_values = neg_values + pos_values
+        
+        self.register_buffer("quantiles", torch.tensor(fp4_values, dtype=torch.float32))
+        
+    def register_buffer(self, name, tensor):
+        setattr(self, name, tensor)
+
+    def quantize(self, x: torch.Tensor):
+        """
+        Quantizes the input tensor using FP4.
+        Returns the quantized values mapped to the FP4 quantiles, and the scale.
+        """
+        self.scale = x.abs().max()
+        if self.scale == 0:
+            return torch.zeros_like(x), self.scale
+            
+        x_norm = x / self.scale
+        
+        diffs = torch.abs(x_norm.unsqueeze(-1) - self.quantiles.to(x.device))
+        indices = torch.argmin(diffs, dim=-1)
+        
+        qx = self.quantiles.to(x.device)[indices]
+        return qx, self.scale
+
+    def dequantize(self, qx: torch.Tensor, scale: torch.Tensor):
+        """
+        Dequantizes the FP4 representation back to original scale.
+        """
+        return qx * scale

--- a/tests/test_nf4_fp4.py
+++ b/tests/test_nf4_fp4.py
@@ -1,0 +1,69 @@
+import torch
+import pytest
+
+from inwhale.llm.formats import NF4Quantizer, FP4Quantizer
+
+def test_nf4_quantizer():
+    # Setup
+    quantizer = NF4Quantizer()
+    
+    # Simple input
+    x = torch.tensor([-2.0, -1.0, 0.0, 1.0, 2.0], dtype=torch.float32)
+    
+    # Process
+    qx, scale = quantizer.quantize(x)
+    x_dequant = quantizer.dequantize(qx, scale)
+    
+    # Assertions
+    # Scale should be max(abs(x)) = 2.0
+    assert scale.item() == 2.0
+    
+    # Max value 2.0 should map to max NF4 quantile 1.0, then back to 2.0
+    # Min value -2.0 should map to min NF4 quantile -1.0, then back to -2.0
+    assert torch.isclose(x_dequant[0], torch.tensor(-2.0))
+    assert torch.isclose(x_dequant[-1], torch.tensor(2.0))
+    
+    # Lengths should match
+    assert qx.shape == x.shape
+    assert x_dequant.shape == x.shape
+
+
+def test_fp4_quantizer():
+    # Setup
+    quantizer = FP4Quantizer()
+    
+    # Simple input
+    x = torch.tensor([-3.0, -1.5, 0.0, 1.5, 3.0], dtype=torch.float32)
+    
+    # Process
+    qx, scale = quantizer.quantize(x)
+    x_dequant = quantizer.dequantize(qx, scale)
+    
+    # Assertions
+    # Scale should be max(abs(x)) = 3.0
+    assert scale.item() == 3.0
+    
+    # Max value 3.0 should map to max FP4 quantile 1.0, then back to 3.0
+    assert torch.isclose(x_dequant[0], torch.tensor(-3.0))
+    assert torch.isclose(x_dequant[-1], torch.tensor(3.0))
+
+
+def test_nf4_zero_tensor():
+    # Test edge case with all zeros
+    quantizer = NF4Quantizer()
+    x = torch.zeros(5, dtype=torch.float32)
+    qx, scale = quantizer.quantize(x)
+    x_dequant = quantizer.dequantize(qx, scale)
+    
+    assert scale.item() == 0.0
+    assert torch.all(x_dequant == 0.0)
+
+def test_fp4_zero_tensor():
+    # Test edge case with all zeros
+    quantizer = FP4Quantizer()
+    x = torch.zeros(5, dtype=torch.float32)
+    qx, scale = quantizer.quantize(x)
+    x_dequant = quantizer.dequantize(qx, scale)
+    
+    assert scale.item() == 0.0
+    assert torch.all(x_dequant == 0.0)


### PR DESCRIPTION

I implemented NF4 and FP4 formats for the LLM specific quantization category. Added the necessary quantizer classes, along with docstrings explaining the mathematics. I also included a test suite and a demo script to compare their performance on normally distributed weights.

Worked on issue #52 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added NF4 and FP4 quantizers for 4-bit weight quantization and reconstruction
  * Included example script demonstrating quantization performance comparison with reconstruction error metrics

* **Documentation**
  * Restructured pull request guidelines for improved clarity

* **Tests**
  * Added test coverage for quantization roundtrip operations and edge cases

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/cneuralnetwork/inwhale/pull/92)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->